### PR TITLE
Bump hedgehog upper bound from <1.5 to <1.6

### DIFF
--- a/system-linux-proc.cabal
+++ b/system-linux-proc.cabal
@@ -50,6 +50,6 @@ test-suite test
 
   build-depends:       base                          >= 4.8         && < 5.0
                      , directory                     == 1.3.*
-                     , hedgehog                      >= 1.0         && < 1.5
+                     , hedgehog                      >= 1.0         && < 1.6
                      , pretty-show                   == 1.10.*
                      , system-linux-proc


### PR DESCRIPTION
This is needed since `hedgehog-1.5` came out.

In particular, `hedgehog-1.5` will soon become the version on Stackage, so we need to bump the bounds so the tests can run for this package. https://github.com/commercialhaskell/stackage/issues/7489