### PR TITLE
allow hedgehog-1.6

### DIFF
--- a/system-linux-proc.cabal
+++ b/system-linux-proc.cabal
@@ -51,6 +51,6 @@ test-suite test
                       Test.System.Linux.Proc.Hedgehog
 
   build-depends:       base                          >= 4.8         && < 5.0
-                     , hedgehog                      >= 1.0         && < 1.6
+                     , hedgehog                      >= 1.0         && < 1.7
                      , pretty-show                   == 1.10.*
                      , system-linux-proc


### PR DESCRIPTION
To address https://github.com/commercialhaskell/stackage/issues/7840

Tested locally and it seems to work fine to bump this bound.
